### PR TITLE
feat: move registration code to CLI, don't require EL ECDSA key unless registering

### DIFF
--- a/cli/actions/deposit_into_strategy.go
+++ b/cli/actions/deposit_into_strategy.go
@@ -29,7 +29,7 @@ func DepositIntoStrategy(ctx *cli.Context) error {
 	}
 	log.Println("Config:", string(configJson))
 
-	operator, err := operator.NewOperatorFromConfig(nodeConfig)
+	operator, err := operator.NewOperatorFromConfig(nodeConfig, nil)
 	if err != nil {
 		return err
 	}

--- a/cli/actions/print_operator_status.go
+++ b/cli/actions/print_operator_status.go
@@ -26,7 +26,7 @@ func PrintOperatorStatus(ctx *cli.Context) error {
 	}
 	log.Println("Config:", string(configJson))
 
-	operator, err := operator.NewOperatorFromConfig(nodeConfig)
+	operator, err := operator.NewOperatorFromConfig(nodeConfig, nil)
 	if err != nil {
 		return err
 	}

--- a/cli/actions/register_operator_with_avs.go
+++ b/cli/actions/register_operator_with_avs.go
@@ -28,7 +28,7 @@ func RegisterOperatorWithAvs(ctx *cli.Context) error {
 	}
 	log.Println("Config:", string(configJson))
 
-	operator, err := operator.NewOperatorFromConfig(nodeConfig)
+	operator, err := operator.NewOperatorFromConfig(nodeConfig, nil)
 	if err != nil {
 		return err
 	}

--- a/cli/actions/register_operator_with_eigenlayer.go
+++ b/cli/actions/register_operator_with_eigenlayer.go
@@ -27,7 +27,7 @@ func RegisterOperatorWithEigenlayer(ctx *cli.Context) error {
 	}
 	log.Println("Config:", string(configJson))
 
-	operator, err := operator.NewOperatorFromConfig(nodeConfig)
+	operator, err := operator.NewOperatorFromConfig(nodeConfig, nil)
 	if err != nil {
 		return err
 	}

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -3,6 +3,7 @@ package operator
 import (
 	"context"
 	"fmt"
+	"os"
 	"slices"
 	"sync/atomic"
 
@@ -115,15 +116,15 @@ func NewOperatorFromConfig(c types.NodeConfig, sidecarStatePtr *atomic.Value) (*
 		}
 	}
 
-	// blsKeyPassword, ok := os.LookupEnv("OPERATOR_BLS_KEY_PASSWORD")
-	// if !ok {
-	// 	logger.Warnf("OPERATOR_BLS_KEY_PASSWORD env var not set. using empty string")
-	// }
-	// blsKeyPair, err := bls.ReadPrivateKeyFromFile(c.BlsPrivateKeyStorePath, blsKeyPassword)
-	// if err != nil {
-	// 	logger.Errorf("Cannot parse bls private key", "err", err)
-	// 	return nil, err
-	// }
+	blsKeyPassword, ok := os.LookupEnv("OPERATOR_BLS_KEY_PASSWORD")
+	if !ok {
+		logger.Warnf("OPERATOR_BLS_KEY_PASSWORD env var not set. using empty string")
+	}
+	blsKeyPair, err := bls.ReadPrivateKeyFromFile(c.BlsPrivateKeyStorePath, blsKeyPassword)
+	if err != nil {
+		logger.Errorf("Cannot parse bls private key", "err", err)
+		return nil, err
+	}
 
 	// TODO(samlaf): should we add the chainId to the config instead?
 	// this way we can prevent creating a signer that signs on mainnet by mistake
@@ -232,7 +233,7 @@ func NewOperatorFromConfig(c types.NodeConfig, sidecarStatePtr *atomic.Value) (*
 		avsSubscriber: avsSubscriber,
 		// eigenlayerReader:                   sdkClients.ElChainReader,
 		// eigenlayerWriter:                   sdkClients.ElChainWriter,
-		// blsKeypair:                         blsKeyPair,
+		blsKeypair:                         blsKeyPair,
 		operatorAddr:                       common.HexToAddress(c.OperatorAddress),
 		aggregatorServerIpPortAddr:         c.AggregatorServerIpPortAddress,
 		aggregatorRpcClient:                aggregatorRpcClient,

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -322,7 +322,7 @@ func (o *Operator) ProcessNewTaskCreatedLog(newTaskCreatedLog *cstaskmanager.Con
 	for {
 		resp, err := o.zrChainClient.ValidationQueryClient.BondedValidators(context.Background(), pageReq)
 		if err != nil {
-			o.logger.Error("Error getting unbonded validators", "err", err)
+			o.logger.Error("Error getting active validator set for zrChain", "err", err)
 		}
 
 		for _, validator := range resp.Validators {

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -3,12 +3,10 @@ package operator
 import (
 	"context"
 	"fmt"
-	"os"
 	"slices"
 	"sync/atomic"
 
 	"github.com/cosmos/cosmos-sdk/types/query"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -21,26 +19,20 @@ import (
 
 	"github.com/Zenrock-Foundation/zrchain/v5/go-client"
 
-	"github.com/Layr-Labs/eigensdk-go/chainio/clients"
 	sdkelcontracts "github.com/Layr-Labs/eigensdk-go/chainio/clients/elcontracts"
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/eth"
-	"github.com/Layr-Labs/eigensdk-go/chainio/clients/wallet"
-	"github.com/Layr-Labs/eigensdk-go/chainio/txmgr"
 	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
-	sdkecdsa "github.com/Layr-Labs/eigensdk-go/crypto/ecdsa"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	sdklogging "github.com/Layr-Labs/eigensdk-go/logging"
 	sdkmetrics "github.com/Layr-Labs/eigensdk-go/metrics"
-	"github.com/Layr-Labs/eigensdk-go/metrics/collectors/economic"
 	rpccalls "github.com/Layr-Labs/eigensdk-go/metrics/collectors/rpc_calls"
 	"github.com/Layr-Labs/eigensdk-go/nodeapi"
-	"github.com/Layr-Labs/eigensdk-go/signerv2"
 	sdktypes "github.com/Layr-Labs/eigensdk-go/types"
 
 	sidecartypes "github.com/Zenrock-Foundation/zrchain/v5/sidecar/shared"
 )
 
-const AVS_NAME = "incredible-squaring"
+const AVS_NAME = "zenrock-avs"
 const SEM_VER = "0.0.1"
 
 type Operator struct {
@@ -123,69 +115,73 @@ func NewOperatorFromConfig(c types.NodeConfig, sidecarStatePtr *atomic.Value) (*
 		}
 	}
 
-	blsKeyPassword, ok := os.LookupEnv("OPERATOR_BLS_KEY_PASSWORD")
-	if !ok {
-		logger.Warnf("OPERATOR_BLS_KEY_PASSWORD env var not set. using empty string")
-	}
-	blsKeyPair, err := bls.ReadPrivateKeyFromFile(c.BlsPrivateKeyStorePath, blsKeyPassword)
-	if err != nil {
-		logger.Errorf("Cannot parse bls private key", "err", err)
-		return nil, err
-	}
+	// blsKeyPassword, ok := os.LookupEnv("OPERATOR_BLS_KEY_PASSWORD")
+	// if !ok {
+	// 	logger.Warnf("OPERATOR_BLS_KEY_PASSWORD env var not set. using empty string")
+	// }
+	// blsKeyPair, err := bls.ReadPrivateKeyFromFile(c.BlsPrivateKeyStorePath, blsKeyPassword)
+	// if err != nil {
+	// 	logger.Errorf("Cannot parse bls private key", "err", err)
+	// 	return nil, err
+	// }
+
 	// TODO(samlaf): should we add the chainId to the config instead?
 	// this way we can prevent creating a signer that signs on mainnet by mistake
 	// if the config says chainId=5, then we can only create a goerli signer
-	chainId, err := ethRpcClient.ChainID(context.Background())
-	if err != nil {
-		logger.Error("Cannot get chainId", "err", err)
-		return nil, err
-	}
+	// chainId, err := ethRpcClient.ChainID(context.Background())
+	// if err != nil {
+	// 	logger.Error("Cannot get chainId", "err", err)
+	// 	return nil, err
+	// }
 
-	ecdsaKeyPassword, ok := os.LookupEnv("OPERATOR_ECDSA_KEY_PASSWORD")
-	if !ok {
-		logger.Warnf("OPERATOR_ECDSA_KEY_PASSWORD env var not set. using empty string")
-	}
+	// ecdsaKeyPassword, ok := os.LookupEnv("OPERATOR_ECDSA_KEY_PASSWORD")
+	// if !ok {
+	// 	logger.Warnf("OPERATOR_ECDSA_KEY_PASSWORD env var not set. using empty string")
+	// }
 
-	signerV2, _, err := signerv2.SignerFromConfig(signerv2.Config{
-		KeystorePath: c.EcdsaPrivateKeyStorePath,
-		Password:     ecdsaKeyPassword,
-	}, chainId)
-	if err != nil {
-		panic(err)
-	}
-	chainioConfig := clients.BuildAllConfig{
-		EthHttpUrl:                 c.EthRpcUrl,
-		EthWsUrl:                   c.EthWsUrl,
-		RegistryCoordinatorAddr:    c.AVSRegistryCoordinatorAddress,
-		OperatorStateRetrieverAddr: c.OperatorStateRetrieverAddress,
-		AvsName:                    AVS_NAME,
-		PromMetricsIpPortAddress:   c.EigenMetricsIpPortAddress,
-	}
-	operatorEcdsaPrivateKey, err := sdkecdsa.ReadKey(
-		c.EcdsaPrivateKeyStorePath,
-		ecdsaKeyPassword,
-	)
-	if err != nil {
-		return nil, err
-	}
-	sdkClients, err := clients.BuildAll(chainioConfig, operatorEcdsaPrivateKey, logger)
-	if err != nil {
-		panic(err)
-	}
-	skWallet, err := wallet.NewPrivateKeyWallet(ethRpcClient, signerV2, common.HexToAddress(c.OperatorAddress), logger)
-	if err != nil {
-		panic(err)
-	}
-	txMgr := txmgr.NewSimpleTxManager(skWallet, ethRpcClient, logger, common.HexToAddress(c.OperatorAddress))
+	// signerV2, _, err := signerv2.SignerFromConfig(signerv2.Config{
+	// 	KeystorePath: c.EcdsaPrivateKeyStorePath,
+	// 	Password:     ecdsaKeyPassword,
+	// }, chainId)
+	// if err != nil {
+	// 	panic(err)
+	// }
 
-	avsWriter, err := chainio.BuildAvsWriter(
-		txMgr, common.HexToAddress(c.AVSRegistryCoordinatorAddress),
-		common.HexToAddress(c.OperatorStateRetrieverAddress), ethRpcClient, logger,
-	)
-	if err != nil {
-		logger.Error("Cannot create AvsWriter", "err", err)
-		return nil, err
-	}
+	// chainioConfig := clients.BuildAllConfig{
+	// 	EthHttpUrl:                 c.EthRpcUrl,
+	// 	EthWsUrl:                   c.EthWsUrl,
+	// 	RegistryCoordinatorAddr:    c.AVSRegistryCoordinatorAddress,
+	// 	OperatorStateRetrieverAddr: c.OperatorStateRetrieverAddress,
+	// 	AvsName:                    AVS_NAME,
+	// 	PromMetricsIpPortAddress:   c.EigenMetricsIpPortAddress,
+	// }
+
+	// operatorEcdsaPrivateKey, err := sdkecdsa.ReadKey(
+	// 	c.EcdsaPrivateKeyStorePath,
+	// 	ecdsaKeyPassword,
+	// )
+	// if err != nil {
+	// 	return nil, err
+	// }
+
+	// sdkClients, err := clients.BuildAll(chainioConfig, operatorEcdsaPrivateKey, logger)
+	// if err != nil {
+	// 	panic(err)
+	// }
+	// skWallet, err := wallet.NewPrivateKeyWallet(ethRpcClient, signerV2, common.HexToAddress(c.OperatorAddress), logger)
+	// if err != nil {
+	// 	panic(err)
+	// }
+	// txMgr := txmgr.NewSimpleTxManager(skWallet, ethRpcClient, logger, common.HexToAddress(c.OperatorAddress))
+
+	// avsWriter, err := chainio.BuildAvsWriter(
+	// 	txMgr, common.HexToAddress(c.AVSRegistryCoordinatorAddress),
+	// 	common.HexToAddress(c.OperatorStateRetrieverAddress), ethRpcClient, logger,
+	// )
+	// if err != nil {
+	// 	logger.Error("Cannot create AvsWriter", "err", err)
+	// 	return nil, err
+	// }
 
 	avsReader, err := chainio.BuildAvsReader(
 		common.HexToAddress(c.AVSRegistryCoordinatorAddress),
@@ -205,13 +201,13 @@ func NewOperatorFromConfig(c types.NodeConfig, sidecarStatePtr *atomic.Value) (*
 
 	// We must register the economic metrics separately because they are exported metrics (from jsonrpc or subgraph calls)
 	// and not instrumented metrics: see https://prometheus.io/docs/instrumenting/writing_clientlibs/#overall-structure
-	quorumNames := map[sdktypes.QuorumNum]string{
-		0: "quorum0",
-	}
-	economicMetricsCollector := economic.NewCollector(
-		sdkClients.ElChainReader, sdkClients.AvsRegistryChainReader,
-		AVS_NAME, logger, common.HexToAddress(c.OperatorAddress), quorumNames)
-	reg.MustRegister(economicMetricsCollector)
+	// quorumNames := map[sdktypes.QuorumNum]string{
+	// 	0: "quorum0",
+	// }
+	// economicMetricsCollector := economic.NewCollector(
+	// 	sdkClients.ElChainReader, sdkClients.AvsRegistryChainReader,
+	// 	AVS_NAME, logger, common.HexToAddress(c.OperatorAddress), quorumNames)
+	// reg.MustRegister(economicMetricsCollector)
 
 	aggregatorRpcClient, err := NewAggregatorRpcClient(c.AggregatorServerIpPortAddress, logger, avsAndEigenMetrics)
 	if err != nil {
@@ -225,18 +221,18 @@ func NewOperatorFromConfig(c types.NodeConfig, sidecarStatePtr *atomic.Value) (*
 	}
 
 	operator := &Operator{
-		config:                             c,
-		logger:                             logger,
-		metricsReg:                         reg,
-		metrics:                            avsAndEigenMetrics,
-		nodeApi:                            nodeApi,
-		ethClient:                          ethRpcClient,
-		avsWriter:                          avsWriter,
-		avsReader:                          avsReader,
-		avsSubscriber:                      avsSubscriber,
-		eigenlayerReader:                   sdkClients.ElChainReader,
-		eigenlayerWriter:                   sdkClients.ElChainWriter,
-		blsKeypair:                         blsKeyPair,
+		config:     c,
+		logger:     logger,
+		metricsReg: reg,
+		metrics:    avsAndEigenMetrics,
+		nodeApi:    nodeApi,
+		ethClient:  ethRpcClient,
+		// avsWriter:                          avsWriter,
+		avsReader:     avsReader,
+		avsSubscriber: avsSubscriber,
+		// eigenlayerReader:                   sdkClients.ElChainReader,
+		// eigenlayerWriter:                   sdkClients.ElChainWriter,
+		// blsKeypair:                         blsKeyPair,
 		operatorAddr:                       common.HexToAddress(c.OperatorAddress),
 		aggregatorServerIpPortAddr:         c.AggregatorServerIpPortAddress,
 		aggregatorRpcClient:                aggregatorRpcClient,
@@ -247,29 +243,21 @@ func NewOperatorFromConfig(c types.NodeConfig, sidecarStatePtr *atomic.Value) (*
 		sidecarStatePtr:                    sidecarStatePtr,
 	}
 
-	// operatorIsRegistered, err := operator.avsReader.IsOperatorRegistered(&bind.CallOpts{}, operator.operatorAddr)
-	// if err != nil {
-	// 	logger.Error("Error checking if operator is registered", "err", err)
-	// 	return nil, err
-	// }
-	// if !operatorIsRegistered {
-	// logger.Info("Operator is not registered. Registering operator...")
-	operator.registerOperatorOnStartup(operatorEcdsaPrivateKey, common.HexToAddress(c.TokenStrategyAddr))
-	// }
+	// operator.registerOperatorOnStartup(operatorEcdsaPrivateKey)
 
 	// OperatorId is set in contract during registration so we get it after registering operator.
-	operatorId, err := sdkClients.AvsRegistryChainReader.GetOperatorId(&bind.CallOpts{}, operator.operatorAddr)
-	if err != nil {
-		logger.Error("Cannot get operator id", "err", err)
-		return nil, err
-	}
-	operator.operatorId = operatorId
-	logger.Info("Operator info",
-		"operatorId", operatorId,
-		"operatorAddr", c.OperatorAddress,
-		"operatorG1Pubkey", operator.blsKeypair.GetPubKeyG1(),
-		"operatorG2Pubkey", operator.blsKeypair.GetPubKeyG2(),
-	)
+	// operatorId, err := sdkClients.AvsRegistryChainReader.GetOperatorId(&bind.CallOpts{}, operator.operatorAddr)
+	// if err != nil {
+	// 	logger.Error("Cannot get operator id", "err", err)
+	// 	return nil, err
+	// }
+	// operator.operatorId = operatorId
+	// logger.Info("Operator info",
+	// 	"operatorId", operatorId,
+	// 	"operatorAddr", c.OperatorAddress,
+	// 	"operatorG1Pubkey", operator.blsKeypair.GetPubKeyG1(),
+	// 	"operatorG2Pubkey", operator.blsKeypair.GetPubKeyG2(),
+	// )
 
 	return operator, nil
 

--- a/operator/registration.go
+++ b/operator/registration.go
@@ -20,10 +20,7 @@ import (
 	eigenSdkTypes "github.com/Layr-Labs/eigensdk-go/types"
 )
 
-func (o *Operator) registerOperatorOnStartup(
-	operatorEcdsaPrivateKey *ecdsa.PrivateKey,
-	tokenStrategyAddr common.Address,
-) {
+func (o *Operator) registerOperatorOnStartup(operatorEcdsaPrivateKey *ecdsa.PrivateKey) {
 	if err := o.RegisterOperatorWithEigenlayer(); err != nil {
 		// This error might only be that the operator was already registered with eigenlayer, so we don't want to fatal
 		o.logger.Debug("Error registering operator with eigenlayer", "err", err)
@@ -31,52 +28,12 @@ func (o *Operator) registerOperatorOnStartup(
 		o.logger.Infof("Registered operator with eigenlayer")
 	}
 
-	// TODO: shouldn't hardcode value here
-	amount := big.NewInt(10000000000000000)
-	if err := o.DepositIntoStrategy(tokenStrategyAddr, amount); err != nil {
-		o.logger.Debug("Error depositing into strategy", "err", err)
-	} else {
-		o.logger.Infof("Deposited %s into strategy %s", amount, tokenStrategyAddr)
-	}
-
 	if err := o.RegisterOperatorWithAvs(operatorEcdsaPrivateKey); err != nil {
 		o.logger.Debug("Error registering operator with avs", "err", err)
 	} else {
 		o.logger.Infof("Registered operator with avs")
 	}
-
-	// if err := o.DelegateServiceManager(o.config.OperatorValidatorAddress, amount); err != nil {
-	// 	o.logger.Debug("Error delegating via service manager", "err", err)
-	// } else {
-	// 	o.logger.Infof("Delegated AVS tokens via ZRServiceManager contract")
-	// }
 }
-
-// func (o *Operator) DelegateServiceManager(validatorAddr string, amount *big.Int) error {
-// 	serviceManager, err := avs.NewContractZrServiceManager(common.HexToAddress(o.config.ServiceManagerAddress), o.ethClient)
-// 	if err != nil {
-// 		o.logger.Fatal("Error creating service manager contract interface", "err", err)
-// 		return err
-// 	}
-
-// 	txOpts, err := o.avsWriter.TxMgr.GetNoSendTxOpts()
-// 	if err != nil {
-// 		o.logger.Errorf("Error getting txOpts")
-// 		return err
-// 	}
-
-// 	tx, err := serviceManager.Delegate(txOpts, validatorAddr, amount)
-// 	if err != nil {
-// 		o.logger.Debug("Error creating Delegate tx")
-// 		return err
-// 	}
-
-// 	if _, err = o.avsWriter.TxMgr.Send(context.Background(), tx); err != nil {
-// 		return errors.New("failed to send tx with err: " + err.Error())
-// 	}
-
-// 	return nil
-// }
 
 func (o *Operator) RegisterOperatorWithEigenlayer() error {
 	op := eigenSdkTypes.Operator{


### PR DESCRIPTION
Moved registration code to CLI so it doesn't happen on startup and removed requirement for keys on normal sidecar operation (not during registration) as per validator request